### PR TITLE
chore: add pullpolicy and digest for specifying an image for knative serving

### DIFF
--- a/src/serverless.js
+++ b/src/serverless.js
@@ -97,24 +97,24 @@ class KnativeServing extends Component {
     return kc.makeApiClient(type)
   }
 
-  getManifest({ knativeGroup, knativeVersion, name, namespace, registryAddress, repository, tag, digest, pullPolicy }) {
+  getManifest(svc) {
     const imageConfig = {}
-    if (digest) {
-      imageConfig.image = `${registryAddress}/${repository}@${digest}`
-    } else if (tag) {
-      imageConfig.image = `${registryAddress}/${repository}:${tag}`
+    if (svc.digest) {
+      imageConfig.image = `${svc.registryAddress}/${svc.repository}@${svc.digest}`
+    } else if (svc.tag) {
+      imageConfig.image = `${svc.registryAddress}/${svc.repository}:${svc.tag}`
     } else {
-      imageConfig.image = `${registryAddress}/${repository}:latest`
+      imageConfig.image = `${svc.registryAddress}/${svc.repository}:latest`
     }
-    if (pullPolicy) {
-      imageConfig.imagePullPolicy = pullPolicy
+    if (svc.pullPolicy) {
+      imageConfig.imagePullPolicy = svc.pullPolicy
     }
     return {
-      apiVersion: `${knativeGroup}/${knativeVersion}`,
+      apiVersion: `${svc.knativeGroup}/${svc.knativeVersion}`,
       kind: 'Service',
       metadata: {
-        name,
-        namespace
+        name: svc.name,
+        namespace: svc.namespace
       },
       spec: {
         template: {

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -97,7 +97,18 @@ class KnativeServing extends Component {
     return kc.makeApiClient(type)
   }
 
-  getManifest({ knativeGroup, knativeVersion, name, namespace, registryAddress, repository, tag }) {
+  getManifest({ knativeGroup, knativeVersion, name, namespace, registryAddress, repository, tag, digest, pullPolicy }) {
+    const imageConfig = {}
+    if (digest) {
+      imageConfig.image = `${registryAddress}/${repository}@${digest}`
+    } else if (tag) {
+      imageConfig.image = `${registryAddress}/${repository}:${tag}`
+    } else {
+      imageConfig.image = `${registryAddress}/${repository}:latest`
+    }
+    if (pullPolicy) {
+      imageConfig.imagePullPolicy = pullPolicy
+    }
     return {
       apiVersion: `${knativeGroup}/${knativeVersion}`,
       kind: 'Service',
@@ -109,9 +120,7 @@ class KnativeServing extends Component {
         template: {
           spec: {
             containers: [
-              {
-                image: `${registryAddress}/${repository}:${tag}`
-              }
+              imageConfig
             ]
           }
         }


### PR DESCRIPTION
Digest are very useful to trigger redeployments for your Knative deployments.
Same for imagePull policy